### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :crete]
 
   def index
+    @item = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/shipping_area.rb
+++ b/app/models/shipping_area.rb
@@ -1,6 +1,6 @@
 class ShippingArea < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---'},
+    { id: 1, name: '---' },
     { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
     { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
     { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,27 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @item.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+      
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.selling_price %>円<br><%= item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +155,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% end %>
+
+      <% if @item.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +176,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+
+      <% end %>
+    
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態がなければ登録できない' do
         @item.product_condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Product condition must be other than 1')
       end
 
       it 'カテゴリーがなければ登録できない' do
@@ -40,11 +40,11 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
-      
+
       it '発送元の地域がなければ登録できない' do
         @item.shipping_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping area must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping area must be other than 1')
       end
 
       it '配送料の負担がなければ登録できない' do
@@ -94,7 +94,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Selling price is not included in the list')
       end
       it '販売価格があっても10000000以上では登録できない' do
-        @item.selling_price = 10000000
+        @item.selling_price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Selling price is not included in the list')
       end


### PR DESCRIPTION
# What
商品を一覧で表示する機能を追加した。

# Why
誰が何を出品したかを一覧で表示させるため

商品を出品していない場合はサンプル画像を表示させる。
https://i.gyazo.com/025eb0974b424dce3bc74a4635eb2e3b.mp4f

商品を出品するとトップページに遷移して出品した情報が反映されていて
尚且つ商品がある場合はサンプル画像は表示しない。
https://i.gyazo.com/c9f9b0b22b7002cf90d2c2d19e6ba9e0.mp4

ログインしていなくても商品は見れる。
https://i.gyazo.com/c7e230b757c24827182095c3359b57b3.mp4

最新の出品は上に表示させている。
https://i.gyazo.com/d60df50855a16cd67a0849f2d6c5b847.mp4
